### PR TITLE
일정 상세 기본 정보 제공 API

### DIFF
--- a/src/docs/asciidoc/travel.adoc
+++ b/src/docs/asciidoc/travel.adoc
@@ -84,6 +84,25 @@ include::{snippets}/travels/list/response-fields.adoc[]
 include::{snippets}/travels/list-anonymous/http-response.adoc[]
 include::{snippets}/travels/list-anonymous/response-fields.adoc[]
 
+=== 비로그인 사용자 count 응답
+include::{snippets}/travels/list-anonymous/http-response.adoc[]
+include::{snippets}/travels/list-anonymous/response-fields.adoc[]
+
 === 로그인 비멤버 사용자 count 응답
 include::{snippets}/travels/list-non-member/http-response.adoc[]
 include::{snippets}/travels/list-non-member/response-fields.adoc[]
+
+== 여행 메타 정보 조회
+include::{snippets}/travels/info/path-parameters.adoc[]
+include::{snippets}/travels/info/http-request.adoc[]
+include::{snippets}/travels/info/http-response.adoc[]
+include::{snippets}/travels/info/response-fields.adoc[]
+
+=== 실패: 비로그인 사용자(401)
+include::{snippets}/travels/info-fail-unauthorized/http-response.adoc[]
+
+=== 실패: 여행 없음(404)
+include::{snippets}/travels/info-fail-not-found/http-response.adoc[]
+
+=== 실패: 여행 멤버 아님(404)
+include::{snippets}/travels/info-fail-member-not-found/http-response.adoc[]

--- a/src/docs/asciidoc/travel.adoc
+++ b/src/docs/asciidoc/travel.adoc
@@ -84,10 +84,6 @@ include::{snippets}/travels/list/response-fields.adoc[]
 include::{snippets}/travels/list-anonymous/http-response.adoc[]
 include::{snippets}/travels/list-anonymous/response-fields.adoc[]
 
-=== 비로그인 사용자 count 응답
-include::{snippets}/travels/list-anonymous/http-response.adoc[]
-include::{snippets}/travels/list-anonymous/response-fields.adoc[]
-
 === 로그인 비멤버 사용자 count 응답
 include::{snippets}/travels/list-non-member/http-response.adoc[]
 include::{snippets}/travels/list-non-member/response-fields.adoc[]

--- a/src/main/java/org/triple/backend/travel/controller/TravelItineraryController.java
+++ b/src/main/java/org/triple/backend/travel/controller/TravelItineraryController.java
@@ -8,6 +8,7 @@ import org.triple.backend.auth.session.LoginUser;
 import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
 import org.triple.backend.travel.dto.request.TravelItineraryUpdateRequestDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
+import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
 import org.triple.backend.travel.service.TravelItineraryService;
 
@@ -73,4 +74,12 @@ public class TravelItineraryController {
         travelItineraryService.leaveTravel(travelId, userId);
     }
 
+    @LoginRequired
+    @GetMapping("/{travelId}/info")
+    public TravelItineraryInfoResponseDto getTravelInfo(
+            @PathVariable Long travelId,
+            @LoginUser Long userId
+    ) {
+        return travelItineraryService.getTravelInfo(travelId, userId);
+    }
 }

--- a/src/main/java/org/triple/backend/travel/dto/response/TravelItineraryInfoResponseDto.java
+++ b/src/main/java/org/triple/backend/travel/dto/response/TravelItineraryInfoResponseDto.java
@@ -1,0 +1,42 @@
+package org.triple.backend.travel.dto.response;
+
+import org.triple.backend.travel.entity.TravelItinerary;
+import org.triple.backend.travel.entity.UserRole;
+import org.triple.backend.travel.entity.UserTravelItinerary;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TravelItineraryInfoResponseDto(
+        String title,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        List<TravelMemberDto> members
+) {
+    public record TravelMemberDto(
+            String nickname,
+            String profileUrl,
+            UserRole userRole
+    ) {
+    }
+
+    public static TravelItineraryInfoResponseDto of(
+            final TravelItinerary travelItinerary,
+            final List<UserTravelItinerary> userTravelItineraries
+    ) {
+        List<TravelMemberDto> members = userTravelItineraries.stream()
+                .map(ut -> new TravelMemberDto(
+                        ut.getUser().getNickname(),
+                        ut.getUser().getProfileUrl(),
+                        ut.getUserRole()
+                ))
+                .toList();
+
+        return new TravelItineraryInfoResponseDto(
+                travelItinerary.getTitle(),
+                travelItinerary.getStartAt(),
+                travelItinerary.getEndAt(),
+                members
+        );
+    }
+}

--- a/src/main/java/org/triple/backend/travel/repository/UserTravelItineraryJpaRepository.java
+++ b/src/main/java/org/triple/backend/travel/repository/UserTravelItineraryJpaRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.triple.backend.travel.entity.UserTravelItinerary;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserTravelItineraryJpaRepository extends JpaRepository<UserTravelItinerary, Long> {
@@ -19,6 +20,14 @@ public interface UserTravelItineraryJpaRepository extends JpaRepository<UserTrav
     Optional<UserTravelItinerary> findByUserIdAndTravelItineraryId(
             @Param("userId") Long userId, @Param("travelItineraryId") Long travelItineraryId
     );
+
+    @Query("""
+            SELECT ut
+            FROM UserTravelItinerary ut
+            JOIN FETCH ut.user u
+            WHERE ut.travelItinerary.id = :travelItineraryId
+            """)
+    List<UserTravelItinerary> findAllByTravelItineraryId(@Param("travelItineraryId") Long travelItineraryId);
 
     boolean existsByUserIdAndTravelItineraryId(Long userId, Long travelItineraryId);
 }

--- a/src/main/java/org/triple/backend/travel/service/TravelItineraryService.java
+++ b/src/main/java/org/triple/backend/travel/service/TravelItineraryService.java
@@ -17,6 +17,7 @@ import org.triple.backend.travel.exception.TravelItineraryErrorCode;
 import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
 import org.triple.backend.travel.dto.request.TravelItineraryUpdateRequestDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
+import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
 import org.triple.backend.travel.entity.TravelItinerary;
 import org.triple.backend.travel.entity.UserRole;
@@ -229,6 +230,19 @@ public class TravelItineraryService {
 
     private int normalizePageSize(int size) {
         return Math.min(Math.max(size, MIN_PAGE_SIZE), MAX_PAGE_SIZE);
+    }
+
+    @Transactional(readOnly = true)
+    public TravelItineraryInfoResponseDto getTravelInfo(final Long travelItineraryId, final Long userId) {
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.findByIdAndIsDeletedFalse(travelItineraryId)
+                .orElseThrow(() -> new BusinessException(TravelItineraryErrorCode.TRAVEL_NOT_FOUND));
+
+        if (!userTravelItineraryJpaRepository.existsByUserIdAndTravelItineraryId(userId, travelItineraryId)) {
+            throw new BusinessException(UserTravelItineraryErrorCode.USER_TRAVEL_ITINERARY_NOT_FOUND);
+        }
+
+        List<UserTravelItinerary> members = userTravelItineraryJpaRepository.findAllByTravelItineraryId(travelItineraryId);
+        return TravelItineraryInfoResponseDto.of(travelItinerary, members);
     }
 
     @Transactional

--- a/src/test/java/org/triple/backend/travel/integration/TravelIntegrationTest.java
+++ b/src/test/java/org/triple/backend/travel/integration/TravelIntegrationTest.java
@@ -410,6 +410,58 @@ class TravelIntegrationTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    @DisplayName("여행 메타 정보 조회에 성공한다.")
+    void 여행_메타_정보_조회_성공() throws Exception {
+        User user = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+        userTravelItineraryJpaRepository.save(UserTravelItinerary.of(user, travelItinerary, UserRole.LEADER));
+
+        mockMvc.perform(get("/travels/{travelId}/info", travelItinerary.getId())
+                        .sessionAttr(USER_SESSION_KEY, user.getPublicUuid()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("제주도 여행"))
+                .andExpect(jsonPath("$.startAt").value("2026-03-01T00:00:00"))
+                .andExpect(jsonPath("$.endAt").value("2026-03-05T00:00:00"))
+                .andExpect(jsonPath("$.members.length()").value(1))
+                .andExpect(jsonPath("$.members[0].nickname").value("nick"))
+                .andExpect(jsonPath("$.members[0].userRole").value("LEADER"));
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 여행 메타 정보 조회 시 401을 반환한다.")
+    void 비로그인_사용자_여행_메타_정보_조회_401() throws Exception {
+        mockMvc.perform(get("/travels/{travelId}/info", 1L))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("여행 멤버가 아닌 사용자가 여행 메타 정보 조회 시 404를 반환한다.")
+    void 여행_멤버가_아닌_사용자_여행_메타_정보_조회_404() throws Exception {
+        User outsider = userJpaRepository.save(createUserWithProviderId("kakao-outsider"));
+        User leader = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+        userTravelItineraryJpaRepository.save(UserTravelItinerary.of(leader, travelItinerary, UserRole.LEADER));
+
+        mockMvc.perform(get("/travels/{travelId}/info", travelItinerary.getId())
+                        .sessionAttr(USER_SESSION_KEY, outsider.getPublicUuid()))
+                .andExpect(status().isNotFound());
+    }
+
     private User createUser() {
         return User.builder()
                 .provider(OauthProvider.KAKAO)

--- a/src/test/java/org/triple/backend/travel/unit/controller/TravelControllerTest.java
+++ b/src/test/java/org/triple/backend/travel/unit/controller/TravelControllerTest.java
@@ -13,7 +13,9 @@ import org.triple.backend.global.error.BusinessException;
 import org.triple.backend.travel.controller.TravelItineraryController;
 import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
+import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
+import org.triple.backend.travel.entity.UserRole;
 import org.triple.backend.travel.exception.TravelItineraryErrorCode;
 import org.triple.backend.travel.exception.UserTravelItineraryErrorCode;
 import org.triple.backend.travel.service.TravelItineraryService;
@@ -745,6 +747,118 @@ class TravelControllerTest extends ControllerTest {
                 ));
 
         verify(travelItineraryService, times(1)).browseTravels(eq(10L), eq(null), eq(10), eq(1L));
+    }
+
+    @Test
+    @DisplayName("여행 메타 정보 조회 성공 시 200을 반환한다.")
+    void 여행_메타_정보_조회_성공() throws Exception {
+        Long travelId = 1L;
+        given(sessionManager.getUserId(any())).willReturn(1L);
+        given(sessionManager.getUserIdOrThrow(any())).willReturn(1L);
+        given(travelItineraryService.getTravelInfo(travelId, 1L)).willReturn(
+                new TravelItineraryInfoResponseDto(
+                        "제주도 뚜벅코 탐험",
+                        LocalDateTime.of(2026, 3, 1, 0, 0),
+                        LocalDateTime.of(2026, 3, 5, 0, 0),
+                        List.of(
+                                new TravelItineraryInfoResponseDto.TravelMemberDto("철수", "http://img1", UserRole.LEADER),
+                                new TravelItineraryInfoResponseDto.TravelMemberDto("영희", "http://img2", UserRole.MEMBER)
+                        )
+                )
+        );
+
+        mockMvc.perform(get("/travels/{travelId}/info", travelId)
+                        .requestAttr("LOGIN_USER_ID", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("제주도 뚜벅코 탐험"))
+                .andExpect(jsonPath("$.startAt").value("2026-03-01T00:00:00"))
+                .andExpect(jsonPath("$.endAt").value("2026-03-05T00:00:00"))
+                .andExpect(jsonPath("$.members.length()").value(2))
+                .andExpect(jsonPath("$.members[0].nickname").value("철수"))
+                .andExpect(jsonPath("$.members[0].userRole").value("LEADER"))
+                .andExpect(jsonPath("$.members[1].nickname").value("영희"))
+                .andExpect(jsonPath("$.members[1].userRole").value("MEMBER"))
+                .andDo(document("travels/info",
+                        pathParameters(
+                                parameterWithName("travelId").description("조회할 여행 일정 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("title").description("여행 제목"),
+                                fieldWithPath("startAt").description("시작 일시"),
+                                fieldWithPath("endAt").description("종료 일시"),
+                                fieldWithPath("members").description("여행 멤버 목록"),
+                                fieldWithPath("members[].nickname").description("멤버 닉네임"),
+                                fieldWithPath("members[].profileUrl").description("멤버 프로필 이미지 URL").optional(),
+                                fieldWithPath("members[].userRole").description("멤버 역할 (LEADER / MEMBER)")
+                        )
+                ));
+
+        verify(travelItineraryService, times(1)).getTravelInfo(travelId, 1L);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 여행 메타 정보 조회 시 401을 반환한다.")
+    void 비로그인_사용자가_여행_메타_정보_조회_시_401을_반환한다() throws Exception {
+        given(sessionManager.getUserIdOrThrow(any()))
+                .willThrow(new BusinessException(AuthErrorCode.UNAUTHORIZED));
+
+        mockMvc.perform(get("/travels/{travelId}/info", 1L))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("인증정보가 없거나 만료되었습니다."))
+                .andDo(document("travels/info-fail-unauthorized",
+                        pathParameters(
+                                parameterWithName("travelId").description("조회할 여행 일정 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("오류 메시지")
+                        )
+                ));
+
+        verify(travelItineraryService, never()).getTravelInfo(any(), any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 여행 메타 정보 조회 시 404를 반환한다.")
+    void 존재하지_않는_여행_메타_정보_조회_시_404를_반환한다() throws Exception {
+        Long travelId = 999L;
+        given(sessionManager.getUserIdOrThrow(any())).willReturn(1L);
+        given(travelItineraryService.getTravelInfo(travelId, 1L))
+                .willThrow(new BusinessException(TravelItineraryErrorCode.TRAVEL_NOT_FOUND));
+
+        mockMvc.perform(get("/travels/{travelId}/info", travelId)
+                        .requestAttr("LOGIN_USER_ID", 1L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("해당 여행이 존재하지 않습니다."))
+                .andDo(document("travels/info-fail-not-found",
+                        pathParameters(
+                                parameterWithName("travelId").description("조회할 여행 일정 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("오류 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("여행 멤버가 아닌 사용자가 여행 메타 정보 조회 시 404를 반환한다.")
+    void 여행_멤버가_아닌_사용자가_여행_메타_정보_조회_시_404를_반환한다() throws Exception {
+        Long travelId = 1L;
+        given(sessionManager.getUserIdOrThrow(any())).willReturn(1L);
+        given(travelItineraryService.getTravelInfo(travelId, 1L))
+                .willThrow(new BusinessException(UserTravelItineraryErrorCode.USER_TRAVEL_ITINERARY_NOT_FOUND));
+
+        mockMvc.perform(get("/travels/{travelId}/info", travelId)
+                        .requestAttr("LOGIN_USER_ID", 1L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("여행 내 해당 유저를 찾을 수 없습니다."))
+                .andDo(document("travels/info-fail-member-not-found",
+                        pathParameters(
+                                parameterWithName("travelId").description("조회할 여행 일정 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("오류 메시지")
+                        )
+                ));
     }
 
     private String buildTravelSaveRequestBody(

--- a/src/test/java/org/triple/backend/travel/unit/service/TravelItineraryServiceTest.java
+++ b/src/test/java/org/triple/backend/travel/unit/service/TravelItineraryServiceTest.java
@@ -22,6 +22,7 @@ import org.triple.backend.group.repository.GroupJpaRepository;
 import org.triple.backend.group.repository.UserGroupJpaRepository;
 import org.triple.backend.travel.dto.request.TravelItineraryUpdateRequestDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
+import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.entity.UserRole;
 import org.triple.backend.travel.entity.UserTravelItinerary;
 import org.triple.backend.travel.exception.TravelItineraryErrorCode;
@@ -790,6 +791,66 @@ class TravelItineraryServiceTest {
 
         Assertions.assertThat(saved.getMemberCount()).isEqualTo(2);
         Assertions.assertThat(mappedCount).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("여행 메타 정보 조회 성공 시 title, startAt, endAt, 멤버 목록을 반환한다.")
+    void 여행_메타_정보_조회_성공() {
+        // given
+        User user = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+        userTravelItineraryJpaRepository.save(UserTravelItinerary.of(user, travelItinerary, UserRole.LEADER));
+
+        // when
+        TravelItineraryInfoResponseDto response = travelItineraryService.getTravelInfo(travelItinerary.getId(), user.getId());
+
+        // then
+        Assertions.assertThat(response.title()).isEqualTo("제주도 여행");
+        Assertions.assertThat(response.startAt()).isEqualTo(LocalDateTime.of(2026, 3, 1, 0, 0));
+        Assertions.assertThat(response.endAt()).isEqualTo(LocalDateTime.of(2026, 3, 5, 0, 0));
+        Assertions.assertThat(response.members()).hasSize(1);
+        Assertions.assertThat(response.members().get(0).nickname()).isEqualTo("tester");
+        Assertions.assertThat(response.members().get(0).userRole()).isEqualTo(UserRole.LEADER);
+    }
+
+    @Test
+    @DisplayName("여행 메타 정보 조회 시 여행이 존재하지 않으면 예외를 던진다.")
+    void 여행_메타_정보_조회_시_여행이_없으면_예외() {
+        // given
+        Long invalidTravelId = 999L;
+        Long userId = 1L;
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> travelItineraryService.getTravelInfo(invalidTravelId, userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(TravelItineraryErrorCode.TRAVEL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("여행 메타 정보 조회 시 여행 멤버가 아니면 예외를 던진다.")
+    void 여행_메타_정보_조회_시_멤버가_아니면_예외() {
+        // given
+        User user = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> travelItineraryService.getTravelInfo(travelItinerary.getId(), user.getId()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserTravelItineraryErrorCode.USER_TRAVEL_ITINERARY_NOT_FOUND);
     }
 
     private static Group createGroup() {


### PR DESCRIPTION
## 구현한 내용
- `GET /travels/{travelId}/info` 엔드포인트 추가
- 여행 메타 정보(title, startAt, endAt)와 멤버 목록(nickname, profileUrl, userRole) 반환
- `UserTravelItineraryJpaRepository`에 멤버 목록 조회 쿼리 추가 (user JOIN FETCH)
- Controller/Service/통합 테스트 작성 및 REST Docs 문서화

## 핵심 비즈니스 로직
- 삭제되지 않은 여행인지 검증 → 없으면 404
- 요청한 사용자가 해당 여행의 멤버인지 검증 → 아니면 404
- 검증 통과 시 여행 메타 정보와 전체 멤버 목록 반환