### PR TITLE
계좌 이체 성공 후 TransferStatus 상태값 변경 처리

### DIFF
--- a/src/main/java/org/triple/backend/transfer/controller/TransferController.java
+++ b/src/main/java/org/triple/backend/transfer/controller/TransferController.java
@@ -67,4 +67,10 @@ public class TransferController {
     public void check(@LoginUser final Long userId, @PathVariable final Long transferId) {
         transferService.check(userId, transferId);
     }
+
+    @LoginRequired
+    @PatchMapping("/{transferId}/users/me/done")
+    public void completeMyTransfer(@LoginUser final Long userId, @PathVariable final Long transferId) {
+        transferService.completeMyTransfer(userId, transferId);
+    }
 }

--- a/src/main/java/org/triple/backend/transfer/entity/Transfer.java
+++ b/src/main/java/org/triple/backend/transfer/entity/Transfer.java
@@ -148,4 +148,17 @@ public class Transfer extends BaseEntity {
 
         this.transferStatus = TransferStatus.CONFIRM;
     }
+
+    public void markDone() {
+        if (transferStatus != TransferStatus.CONFIRM) {
+            throw new IllegalStateException("확정된 청구서만 완료 처리할 수 있습니다.");
+        }
+
+        this.transferStatus = TransferStatus.DONE;
+    }
+
+    public boolean isAllPaid() {
+        return transferUsers.stream()
+                .allMatch(TransferUser::isSettled);
+    }
 }

--- a/src/main/java/org/triple/backend/transfer/entity/TransferUser.java
+++ b/src/main/java/org/triple/backend/transfer/entity/TransferUser.java
@@ -57,4 +57,12 @@ public class TransferUser {
         }
         this.remainAmount = newRemainAmount;
     }
+
+    public boolean isSettled() {
+        return remainAmount.compareTo(BigDecimal.ZERO) == 0;
+    }
+
+    public void settle() {
+        this.remainAmount = BigDecimal.ZERO;
+    }
 }

--- a/src/main/java/org/triple/backend/transfer/exception/TransferErrorCode.java
+++ b/src/main/java/org/triple/backend/transfer/exception/TransferErrorCode.java
@@ -17,7 +17,10 @@ public enum TransferErrorCode implements ErrorCode {
     INVOICE_CHECK_NOT_ALLOWED_STATUS(HttpStatus.CONFLICT, "청구서를 확인할 수 없습니다."),
     CONCURRENT_INVOICE_UPDATE(HttpStatus.CONFLICT, "동시에 청구서가 수정되었습니다. 다시 시도해주세요."),
     DELETE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "청구서 생성자만 삭제할 수 있습니다."),
-    DELETE_FORBIDDEN_STATUS(HttpStatus.CONFLICT, "현재 상태에서는 청구서를 삭제할 수 없습니다.");
+    DELETE_FORBIDDEN_STATUS(HttpStatus.CONFLICT, "현재 상태에서는 청구서를 삭제할 수 없습니다."),
+    INVOICE_DONE_NOT_ALLOWED_STATUS(HttpStatus.CONFLICT, "확정된 청구서만 완료 처리할 수 있습니다."),
+    TRANSFER_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 청구서의 멤버가 아닙니다."),
+    ALREADY_TRANSFERRED(HttpStatus.CONFLICT, "이미 이체 완료된 멤버입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/triple/backend/transfer/repository/TransferJpaRepository.java
+++ b/src/main/java/org/triple/backend/transfer/repository/TransferJpaRepository.java
@@ -43,4 +43,15 @@ public interface TransferJpaRepository extends JpaRepository<Transfer, Long> {
            WHERE i.id = :transferId
            """)
     Optional<Transfer> findByIdWithTravelItinerary(Long transferId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "1000"))
+    @Query("""
+           SELECT i
+           FROM Transfer i
+           LEFT JOIN FETCH i.transferUsers tu
+           LEFT JOIN FETCH tu.user
+           WHERE i.id = :transferId
+           """)
+    Optional<Transfer> findByIdForUpdateWithTransferUsers(Long transferId);
 }

--- a/src/main/java/org/triple/backend/transfer/service/TransferService.java
+++ b/src/main/java/org/triple/backend/transfer/service/TransferService.java
@@ -339,4 +339,29 @@ public class TransferService {
         validateStatusOrThrow(transfer, TransferErrorCode.INVOICE_CHECK_NOT_ALLOWED_STATUS);
         transfer.confirm();
     }
+
+    @Transactional
+    public void completeMyTransfer(final Long userId, final Long transferId) {
+        Transfer transfer = transferJpaRepository.findByIdForUpdateWithTransferUsers(transferId)
+                .orElseThrow(() -> new BusinessException(TransferErrorCode.NOT_FOUND_INVOICE));
+
+        if (transfer.getTransferStatus() != TransferStatus.CONFIRM) {
+            throw new BusinessException(TransferErrorCode.INVOICE_DONE_NOT_ALLOWED_STATUS);
+        }
+
+        TransferUser transferUser = transfer.getTransferUsers().stream()
+                .filter(tu -> tu.getUser().getId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(TransferErrorCode.TRANSFER_USER_NOT_FOUND));
+
+        if (transferUser.isSettled()) {
+            throw new BusinessException(TransferErrorCode.ALREADY_TRANSFERRED);
+        }
+
+        transferUser.settle();
+
+        if (transfer.isAllPaid()) {
+            transfer.markDone();
+        }
+    }
 }

--- a/src/test/java/org/triple/backend/transfer/integration/TransferIntegrationTest.java
+++ b/src/test/java/org/triple/backend/transfer/integration/TransferIntegrationTest.java
@@ -773,6 +773,125 @@ class TransferIntegrationTest {
         );
     }
 
+    @Test
+    @DisplayName("이체 완료 요청 성공 시 해당 멤버의 remainAmount가 0이 된다.")
+    void 이체_완료_요청_성공() throws Exception {
+        // given
+        User leader = saveUser("leader-complete-integration");
+        User member = saveUser("member-complete-integration");
+        Group group = saveGroup("이체 완료 통합 테스트 그룹");
+        saveMembership(leader, group, Role.OWNER);
+        saveMembership(member, group, Role.MEMBER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "이체 완료 통합 테스트 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        saveTravelMembership(member, travelItinerary, UserRole.MEMBER);
+        Transfer transfer = saveTransfer(leader, group, travelItinerary, TransferStatus.CONFIRM);
+        TransferUser transferUser = transferUserJpaRepository.save(
+                TransferUser.create(transfer, member, new BigDecimal("10000"))
+        );
+
+        // when & then
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transfer.getId())
+                        .sessionAttr(USER_SESSION_KEY, member.getPublicUuid())
+                        .sessionAttr(CSRF_TOKEN_KEY, CSRF_TOKEN)
+                        .header(CSRF_HEADER, CSRF_TOKEN))
+                .andExpect(status().isOk());
+
+        TransferUser updated = transferUserJpaRepository.findById(transferUser.getId()).orElseThrow();
+        assertThat(updated.getRemainAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        Transfer updatedTransfer = transferJpaRepository.findById(transfer.getId()).orElseThrow();
+        assertThat(updatedTransfer.getTransferStatus()).isEqualTo(TransferStatus.DONE);
+    }
+
+    @Test
+    @DisplayName("모든 멤버 이체 완료 시 Transfer 상태가 DONE으로 변경된다.")
+    void 모든_멤버_이체_완료_시_DONE으로_변경() throws Exception {
+        // given
+        User leader = saveUser("leader-all-complete");
+        User member1 = saveUser("member1-all-complete");
+        User member2 = saveUser("member2-all-complete");
+        Group group = saveGroup("전체 완료 통합 테스트 그룹");
+        saveMembership(leader, group, Role.OWNER);
+        saveMembership(member1, group, Role.MEMBER);
+        saveMembership(member2, group, Role.MEMBER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "전체 완료 통합 테스트 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        saveTravelMembership(member1, travelItinerary, UserRole.MEMBER);
+        saveTravelMembership(member2, travelItinerary, UserRole.MEMBER);
+        Transfer transfer = saveTransfer(leader, group, travelItinerary, TransferStatus.CONFIRM);
+        transferUserJpaRepository.save(TransferUser.create(transfer, member1, new BigDecimal("10000")));
+        transferUserJpaRepository.save(TransferUser.create(transfer, member2, new BigDecimal("20000")));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transfer.getId())
+                        .sessionAttr(USER_SESSION_KEY, member1.getPublicUuid())
+                        .sessionAttr(CSRF_TOKEN_KEY, CSRF_TOKEN)
+                        .header(CSRF_HEADER, CSRF_TOKEN))
+                .andExpect(status().isOk());
+
+        assertThat(transferJpaRepository.findById(transfer.getId()).orElseThrow().getTransferStatus())
+                .isEqualTo(TransferStatus.CONFIRM);
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transfer.getId())
+                        .sessionAttr(USER_SESSION_KEY, member2.getPublicUuid())
+                        .sessionAttr(CSRF_TOKEN_KEY, CSRF_TOKEN)
+                        .header(CSRF_HEADER, CSRF_TOKEN))
+                .andExpect(status().isOk());
+
+        assertThat(transferJpaRepository.findById(transfer.getId()).orElseThrow().getTransferStatus())
+                .isEqualTo(TransferStatus.DONE);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 이체 완료 요청 시 401을 반환한다.")
+    void 비로그인_사용자가_이체_완료_요청_시_401() throws Exception {
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", 1L))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("CONFIRM 상태가 아닌 청구서에 이체 완료 요청 시 409를 반환한다.")
+    void CONFIRM_상태가_아닌_청구서에_이체_완료_요청_시_409() throws Exception {
+        // given
+        User leader = saveUser("leader-invalid-status-integration");
+        User member = saveUser("member-invalid-status-integration");
+        Group group = saveGroup("상태 검증 통합 테스트 그룹");
+        saveMembership(leader, group, Role.OWNER);
+        saveMembership(member, group, Role.MEMBER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "상태 검증 통합 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        saveTravelMembership(member, travelItinerary, UserRole.MEMBER);
+        Transfer transfer = saveTransfer(leader, group, travelItinerary, TransferStatus.UNCONFIRM);
+        transferUserJpaRepository.save(TransferUser.create(transfer, member, new BigDecimal("10000")));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transfer.getId())
+                        .sessionAttr(USER_SESSION_KEY, member.getPublicUuid())
+                        .sessionAttr(CSRF_TOKEN_KEY, CSRF_TOKEN)
+                        .header(CSRF_HEADER, CSRF_TOKEN))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("이미 이체 완료된 멤버의 중복 요청 시 409를 반환한다.")
+    void 이미_이체_완료된_멤버_중복_요청_시_409() throws Exception {
+        // given
+        User leader = saveUser("leader-already-transferred-integration");
+        User member = saveUser("member-already-transferred-integration");
+        Group group = saveGroup("중복 이체 통합 테스트 그룹");
+        saveMembership(leader, group, Role.OWNER);
+        saveMembership(member, group, Role.MEMBER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "중복 이체 통합 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        saveTravelMembership(member, travelItinerary, UserRole.MEMBER);
+        Transfer transfer = saveTransfer(leader, group, travelItinerary, TransferStatus.CONFIRM);
+        transferUserJpaRepository.save(TransferUser.create(transfer, member, BigDecimal.ZERO));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transfer.getId())
+                        .sessionAttr(USER_SESSION_KEY, member.getPublicUuid())
+                        .sessionAttr(CSRF_TOKEN_KEY, CSRF_TOKEN)
+                        .header(CSRF_HEADER, CSRF_TOKEN))
+                .andExpect(status().isConflict());
+    }
+
     private String encryptedUserId(final User user) {
         return uuidCrypto.encrypt(user.getPublicUuid());
     }

--- a/src/test/java/org/triple/backend/transfer/unit/controller/TransferControllerTest.java
+++ b/src/test/java/org/triple/backend/transfer/unit/controller/TransferControllerTest.java
@@ -1464,6 +1464,142 @@ class TransferControllerTest extends ControllerTest {
         verify(transferService, times(1)).delete(1L, transferId);
     }
 
+    @Test
+    @DisplayName("이체 완료 요청 성공 시 200을 반환한다.")
+    void 이체_완료_요청_성공() throws Exception {
+        Long transferId = 1L;
+        mockCsrfValid();
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transferId)
+                        .with(loginSessionAndCsrf()))
+                .andExpect(status().isOk())
+                .andDo(document("transfers/complete-my-transfer",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("transferId").description("이체 완료 처리할 청구서 ID")
+                        )
+                ));
+
+        verify(transferService, times(1)).completeMyTransfer(1L, transferId);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 이체 완료 요청 시 401을 반환한다.")
+    void 비로그인_사용자가_이체_완료_요청_시_401을_반환한다() throws Exception {
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", 1L))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("인증정보가 없거나 만료되었습니다."))
+                .andDo(document("transfers/complete-my-transfer-fail-unauthorized",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("transferId").description("이체 완료 처리할 청구서 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+
+        verify(transferService, never()).completeMyTransfer(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 청구서에 이체 완료 요청 시 404를 반환한다.")
+    void 존재하지_않는_청구서에_이체_완료_요청_시_404를_반환한다() throws Exception {
+        Long transferId = 999L;
+        mockCsrfValid();
+        willThrow(new BusinessException(TransferErrorCode.NOT_FOUND_INVOICE))
+                .given(transferService).completeMyTransfer(eq(1L), eq(transferId));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transferId)
+                        .with(loginSessionAndCsrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("존재하지 않는 청구서 입니다."))
+                .andDo(document("transfers/complete-my-transfer-fail-not-found",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("transferId").description("이체 완료 처리할 청구서 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("CONFIRM 상태가 아닌 청구서에 이체 완료 요청 시 409를 반환한다.")
+    void CONFIRM_상태가_아닌_청구서에_이체_완료_요청_시_409를_반환한다() throws Exception {
+        Long transferId = 1L;
+        mockCsrfValid();
+        willThrow(new BusinessException(TransferErrorCode.INVOICE_DONE_NOT_ALLOWED_STATUS))
+                .given(transferService).completeMyTransfer(eq(1L), eq(transferId));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transferId)
+                        .with(loginSessionAndCsrf()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("확정된 청구서만 완료 처리할 수 있습니다."))
+                .andDo(document("transfers/complete-my-transfer-fail-invalid-status",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("transferId").description("이체 완료 처리할 청구서 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("청구서 멤버가 아닌 사용자의 이체 완료 요청 시 404를 반환한다.")
+    void 청구서_멤버가_아닌_사용자의_이체_완료_요청_시_404를_반환한다() throws Exception {
+        Long transferId = 1L;
+        mockCsrfValid();
+        willThrow(new BusinessException(TransferErrorCode.TRANSFER_USER_NOT_FOUND))
+                .given(transferService).completeMyTransfer(eq(1L), eq(transferId));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transferId)
+                        .with(loginSessionAndCsrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("해당 청구서의 멤버가 아닙니다."))
+                .andDo(document("transfers/complete-my-transfer-fail-not-member",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("transferId").description("이체 완료 처리할 청구서 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("이미 이체 완료된 멤버의 중복 요청 시 409를 반환한다.")
+    void 이미_이체_완료된_멤버의_중복_요청_시_409를_반환한다() throws Exception {
+        Long transferId = 1L;
+        mockCsrfValid();
+        willThrow(new BusinessException(TransferErrorCode.ALREADY_TRANSFERRED))
+                .given(transferService).completeMyTransfer(eq(1L), eq(transferId));
+
+        mockMvc.perform(patch("/transfers/{transferId}/users/me/done", transferId)
+                        .with(loginSessionAndCsrf()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 이체 완료된 멤버입니다."))
+                .andDo(document("transfers/complete-my-transfer-fail-already-transferred",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("transferId").description("이체 완료 처리할 청구서 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
     private String validUpdateInfoBody() {
         return """
                 {

--- a/src/test/java/org/triple/backend/transfer/unit/service/TransferServiceTest.java
+++ b/src/test/java/org/triple/backend/transfer/unit/service/TransferServiceTest.java
@@ -976,6 +976,133 @@ class TransferServiceTest {
                 });
     }
 
+    @Test
+    @DisplayName("이체 완료 요청 시 해당 멤버의 remainAmount가 0이 된다.")
+    void 이체_완료_요청_성공() {
+        // given
+        User leader = saveUser("leader-complete");
+        User member = saveUser("member-complete");
+        Group group = saveGroup("이체 완료 테스트 그룹");
+        saveUserGroup(leader, group, Role.OWNER);
+        saveUserGroup(member, group, Role.MEMBER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "이체 완료 테스트 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        saveTravelMembership(member, travelItinerary, UserRole.MEMBER);
+        Transfer transfer = saveTransfer(group, leader, travelItinerary, TransferStatus.CONFIRM, "이체 완료 청구서");
+        TransferUser transferUser = transferUserJpaRepository.save(TransferUser.create(transfer, member, new BigDecimal("10000")));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        transferService.completeMyTransfer(member.getId(), transfer.getId());
+
+        // then
+        TransferUser updated = transferUserJpaRepository.findById(transferUser.getId()).orElseThrow();
+        assertThat(updated.getRemainAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        Transfer updatedTransfer = transferRepository.findById(transfer.getId()).orElseThrow();
+        assertThat(updatedTransfer.getTransferStatus()).isEqualTo(TransferStatus.DONE);
+    }
+
+    @Test
+    @DisplayName("일부 멤버만 이체 완료 시 Transfer 상태는 CONFIRM을 유지한다.")
+    void 일부_멤버만_이체_완료_시_CONFIRM_유지() {
+        // given
+        User leader = saveUser("leader-partial-complete");
+        User member1 = saveUser("member1-partial-complete");
+        User member2 = saveUser("member2-partial-complete");
+        Group group = saveGroup("부분 완료 테스트 그룹");
+        saveUserGroup(leader, group, Role.OWNER);
+        saveUserGroup(member1, group, Role.MEMBER);
+        saveUserGroup(member2, group, Role.MEMBER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "부분 완료 테스트 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        saveTravelMembership(member1, travelItinerary, UserRole.MEMBER);
+        saveTravelMembership(member2, travelItinerary, UserRole.MEMBER);
+        Transfer transfer = saveTransfer(group, leader, travelItinerary, TransferStatus.CONFIRM, "부분 완료 청구서");
+        transferUserJpaRepository.save(TransferUser.create(transfer, member1, new BigDecimal("10000")));
+        transferUserJpaRepository.save(TransferUser.create(transfer, member2, new BigDecimal("20000")));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        transferService.completeMyTransfer(member1.getId(), transfer.getId());
+
+        // then
+        Transfer updatedTransfer = transferRepository.findById(transfer.getId()).orElseThrow();
+        assertThat(updatedTransfer.getTransferStatus()).isEqualTo(TransferStatus.CONFIRM);
+    }
+
+    @Test
+    @DisplayName("CONFIRM 상태가 아닌 청구서에 이체 완료 요청 시 예외를 던진다.")
+    void CONFIRM_상태가_아닌_청구서에_이체_완료_요청_시_예외() {
+        // given
+        User leader = saveUser("leader-done-status");
+        User member = saveUser("member-done-status");
+        Group group = saveGroup("상태 검증 테스트 그룹");
+        saveUserGroup(leader, group, Role.OWNER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "상태 검증 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        Transfer transfer = saveTransfer(group, leader, travelItinerary, TransferStatus.UNCONFIRM, "상태 검증 청구서");
+        transferUserJpaRepository.save(TransferUser.create(transfer, member, new BigDecimal("10000")));
+
+        // when & then
+        assertThatThrownBy(() -> transferService.completeMyTransfer(member.getId(), transfer.getId()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(TransferErrorCode.INVOICE_DONE_NOT_ALLOWED_STATUS));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 청구서에 이체 완료 요청 시 예외를 던진다.")
+    void 존재하지_않는_청구서에_이체_완료_요청_시_예외() {
+        // when & then
+        assertThatThrownBy(() -> transferService.completeMyTransfer(1L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(TransferErrorCode.NOT_FOUND_INVOICE));
+    }
+
+    @Test
+    @DisplayName("청구서 멤버가 아닌 사용자가 이체 완료 요청 시 예외를 던진다.")
+    void 청구서_멤버가_아닌_사용자가_이체_완료_요청_시_예외() {
+        // given
+        User leader = saveUser("leader-not-member");
+        User outsider = saveUser("outsider-not-member");
+        Group group = saveGroup("멤버 검증 테스트 그룹");
+        saveUserGroup(leader, group, Role.OWNER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "멤버 검증 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        Transfer transfer = saveTransfer(group, leader, travelItinerary, TransferStatus.CONFIRM, "멤버 검증 청구서");
+
+        // when & then
+        assertThatThrownBy(() -> transferService.completeMyTransfer(outsider.getId(), transfer.getId()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(TransferErrorCode.TRANSFER_USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("이미 이체 완료된 멤버가 중복 요청 시 예외를 던진다.")
+    void 이미_이체_완료된_멤버가_중복_요청_시_예외() {
+        // given
+        User leader = saveUser("leader-already-transferred");
+        User member = saveUser("member-already-transferred");
+        Group group = saveGroup("중복 이체 테스트 그룹");
+        saveUserGroup(leader, group, Role.OWNER);
+        TravelItinerary travelItinerary = saveTravelItinerary(group, "중복 이체 테스트 여행");
+        saveTravelMembership(leader, travelItinerary, UserRole.LEADER);
+        Transfer transfer = saveTransfer(group, leader, travelItinerary, TransferStatus.CONFIRM, "중복 이체 청구서");
+        transferUserJpaRepository.save(TransferUser.create(transfer, member, BigDecimal.ZERO));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when & then
+        assertThatThrownBy(() -> transferService.completeMyTransfer(member.getId(), transfer.getId()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(TransferErrorCode.ALREADY_TRANSFERRED));
+    }
+
     private User saveUser(final String providerId) {
         return userJpaRepository.saveAndFlush(
                 User.builder()


### PR DESCRIPTION
## 구현한 내용
토스 QR 계좌이체 성공 후 Transfer 상태를 처리하는 API를 구현합니다.
멤버 개인이 이체 완료를 요청하면 본인의 잔여 금액이 0으로 처리되고, 모든 멤버의 이체가 완료되면 Transfer 상태가 자동으로 DONE으로 전환됩니다.

### API
• `PATCH /transfers/{transferId}/users/me/done` — 본인 이체 완료 처리

## 핵심 비즈니스 로직

### 상태 전환 흐름
`CONFIRM → (모든 멤버 이체 완료 시) → DONE`

- 요청한 유저의 TransferUser.remainAmount를 0으로 설정
- 모든 TransferUser의 remainAmount가 0이면 Transfer 상태를 DONE으로 변경
- CONFIRM 상태의 청구서에만 요청 가능
- 이미 이체 완료된 멤버의 중복 요청 방지
- PESSIMISTIC_WRITE 락 + LEFT JOIN FETCH로 TransferUser를 함께 조회하여 동시 요청 시 데이터 정합성 보장