### PR TITLE
여행 문서 초깃값 조회

### DIFF
--- a/src/main/java/org/triple/backend/travel/controller/TravelItineraryController.java
+++ b/src/main/java/org/triple/backend/travel/controller/TravelItineraryController.java
@@ -7,6 +7,7 @@ import org.triple.backend.auth.jwt.LoginRequired;
 import org.triple.backend.auth.jwt.LoginUser;
 import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
 import org.triple.backend.travel.dto.request.TravelItineraryUpdateRequestDto;
+import org.triple.backend.travel.dto.response.TravelDocInitialStateResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
@@ -81,5 +82,14 @@ public class TravelItineraryController {
             @LoginUser Long userId
     ) {
         return travelItineraryService.getTravelInfo(travelId, userId);
+    }
+
+    @LoginRequired
+    @GetMapping("/{travelId}/doc")
+    public TravelDocInitialStateResponseDto getTravelDocInitialState(
+            @PathVariable Long travelId,
+            @LoginUser Long userId
+    ) {
+        return travelItineraryService.getTravelDocInitialState(travelId, userId);
     }
 }

--- a/src/main/java/org/triple/backend/travel/dto/response/TravelDocInitialStateResponseDto.java
+++ b/src/main/java/org/triple/backend/travel/dto/response/TravelDocInitialStateResponseDto.java
@@ -1,0 +1,22 @@
+package org.triple.backend.travel.dto.response;
+
+import java.util.Base64;
+
+public record TravelDocInitialStateResponseDto(
+        Long travelItineraryId,
+        String state,
+        boolean initialized
+) {
+
+    public static TravelDocInitialStateResponseDto initialized(
+            final Long travelItineraryId,
+            final byte[] state
+    ) {
+        String encodedState = Base64.getEncoder().encodeToString(state);
+        return new TravelDocInitialStateResponseDto(travelItineraryId, encodedState, true);
+    }
+
+    public static TravelDocInitialStateResponseDto empty(final Long travelItineraryId) {
+        return new TravelDocInitialStateResponseDto(travelItineraryId, "", false);
+    }
+}

--- a/src/main/java/org/triple/backend/travel/entity/TravelDoc.java
+++ b/src/main/java/org/triple/backend/travel/entity/TravelDoc.java
@@ -1,0 +1,45 @@
+package org.triple.backend.travel.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "travel_doc")
+public class TravelDoc {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "travel_doc_id")
+    private Long id;
+
+    @Column(name = "travel_itinerary_id", nullable = false, unique = true)
+    private Long travelItineraryId;
+
+    @Lob
+    @Column(name = "state", nullable = false)
+    private byte[] state;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static TravelDoc of(final Long travelItineraryId, final byte[] state) {
+        TravelDoc travelDoc = new TravelDoc();
+        travelDoc.travelItineraryId = travelItineraryId;
+        travelDoc.state = state;
+        return travelDoc;
+    }
+}

--- a/src/main/java/org/triple/backend/travel/repository/TravelDocJpaRepository.java
+++ b/src/main/java/org/triple/backend/travel/repository/TravelDocJpaRepository.java
@@ -1,0 +1,10 @@
+package org.triple.backend.travel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.triple.backend.travel.entity.TravelDoc;
+
+import java.util.Optional;
+
+public interface TravelDocJpaRepository extends JpaRepository<TravelDoc, Long> {
+    Optional<TravelDoc> findByTravelItineraryId(Long travelItineraryId);
+}

--- a/src/main/java/org/triple/backend/travel/service/TravelItineraryService.java
+++ b/src/main/java/org/triple/backend/travel/service/TravelItineraryService.java
@@ -16,13 +16,16 @@ import org.triple.backend.group.repository.UserGroupJpaRepository;
 import org.triple.backend.travel.exception.TravelItineraryErrorCode;
 import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
 import org.triple.backend.travel.dto.request.TravelItineraryUpdateRequestDto;
+import org.triple.backend.travel.dto.response.TravelDocInitialStateResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
+import org.triple.backend.travel.entity.TravelDoc;
 import org.triple.backend.travel.entity.TravelItinerary;
 import org.triple.backend.travel.entity.UserRole;
 import org.triple.backend.travel.entity.UserTravelItinerary;
 import org.triple.backend.travel.exception.UserTravelItineraryErrorCode;
+import org.triple.backend.travel.repository.TravelDocJpaRepository;
 import org.triple.backend.travel.repository.TravelItineraryJpaRepository;
 import org.triple.backend.travel.repository.UserTravelItineraryJpaRepository;
 import org.triple.backend.user.entity.User;
@@ -43,6 +46,7 @@ public class TravelItineraryService {
     private final UserJpaRepository userJpaRepository;
     private final UserTravelItineraryJpaRepository userTravelItineraryJpaRepository;
     private final TravelItineraryJpaRepository travelItineraryJpaRepository;
+    private final TravelDocJpaRepository travelDocJpaRepository;
     private final GroupJpaRepository groupJpaRepository;
     private final UserGroupJpaRepository userGroupJpaRepository;
     private final UserIdentityResolver userIdentityResolver;
@@ -242,6 +246,24 @@ public class TravelItineraryService {
 
         List<UserTravelItinerary> members = userTravelItineraryJpaRepository.findAllByTravelItineraryId(travelItineraryId);
         return TravelItineraryInfoResponseDto.of(travelItinerary, members);
+    }
+
+    @Transactional(readOnly = true)
+    public TravelDocInitialStateResponseDto getTravelDocInitialState(final Long travelItineraryId, final Long userId) {
+        travelItineraryJpaRepository.findByIdAndIsDeletedFalse(travelItineraryId)
+                .orElseThrow(() -> new BusinessException(TravelItineraryErrorCode.TRAVEL_NOT_FOUND));
+
+        boolean isMember = userTravelItineraryJpaRepository.existsByUserIdAndTravelItineraryId(userId, travelItineraryId);
+        if (!isMember) {
+            throw new BusinessException(UserTravelItineraryErrorCode.USER_TRAVEL_ITINERARY_NOT_FOUND);
+        }
+
+        TravelDoc travelDoc = travelDocJpaRepository.findByTravelItineraryId(travelItineraryId)
+                .orElse(null);
+        if (travelDoc == null) {
+            return TravelDocInitialStateResponseDto.empty(travelItineraryId);
+        }
+        return TravelDocInitialStateResponseDto.initialized(travelItineraryId, travelDoc.getState());
     }
 
     @Transactional

--- a/src/test/java/org/triple/backend/travel/unit/controller/TravelControllerTest.java
+++ b/src/test/java/org/triple/backend/travel/unit/controller/TravelControllerTest.java
@@ -11,6 +11,7 @@ import org.triple.backend.common.ControllerTest;
 import org.triple.backend.global.error.BusinessException;
 import org.triple.backend.travel.controller.TravelItineraryController;
 import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
+import org.triple.backend.travel.dto.response.TravelDocInitialStateResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
@@ -828,6 +829,56 @@ class TravelControllerTest extends ControllerTest {
                                 fieldWithPath("message").description("오류 메시지")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("여행 문서 초기값 조회 성공 시 200을 반환한다.")
+    void 여행_문서_초기값_조회_성공() throws Exception {
+        Long travelId = 1L;
+        given(sessionManager.getUserId(any())).willReturn(1L);
+        given(sessionManager.getUserIdOrThrow(any())).willReturn(1L);
+        given(travelItineraryService.getTravelDocInitialState(travelId, 1L))
+                .willReturn(new TravelDocInitialStateResponseDto(travelId, "AAECAw==", true));
+
+        mockMvc.perform(get("/travels/{travelId}/doc", travelId)
+                        .with(loginJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.travelItineraryId").value(1L))
+                .andExpect(jsonPath("$.state").value("AAECAw=="))
+                .andExpect(jsonPath("$.initialized").value(true))
+                .andDo(document("travels/doc",
+                        pathParameters(
+                                parameterWithName("travelId").description("조회할 여행 일정 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("travelItineraryId").description("여행 일정 ID"),
+                                fieldWithPath("state").description("초기 문서 상태(Base64)"),
+                                fieldWithPath("initialized").description("문서 초기화 여부")
+                        )
+                ));
+
+        verify(travelItineraryService, times(1)).getTravelDocInitialState(travelId, 1L);
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자가 여행 문서 초기값 조회 시 401을 반환한다.")
+    void 비로그인_사용자_문서_초기값_조회_실패() throws Exception {
+        given(sessionManager.getUserIdOrThrow(any()))
+                .willThrow(new BusinessException(AuthErrorCode.UNAUTHORIZED));
+
+        mockMvc.perform(get("/travels/{travelId}/doc", 1L))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("인증정보가 없거나 만료되었습니다."))
+                .andDo(document("travels/doc-fail-unauthorized",
+                        pathParameters(
+                                parameterWithName("travelId").description("조회할 여행 일정 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("오류 메시지")
+                        )
+                ));
+
+        verify(travelItineraryService, never()).getTravelDocInitialState(any(), any());
     }
 
     private String buildTravelSaveRequestBody(

--- a/src/test/java/org/triple/backend/travel/unit/service/TravelItineraryServiceTest.java
+++ b/src/test/java/org/triple/backend/travel/unit/service/TravelItineraryServiceTest.java
@@ -21,8 +21,10 @@ import org.triple.backend.group.exception.GroupErrorCode;
 import org.triple.backend.group.repository.GroupJpaRepository;
 import org.triple.backend.group.repository.UserGroupJpaRepository;
 import org.triple.backend.travel.dto.request.TravelItineraryUpdateRequestDto;
+import org.triple.backend.travel.dto.response.TravelDocInitialStateResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryCursorResponseDto;
 import org.triple.backend.travel.dto.response.TravelItineraryInfoResponseDto;
+import org.triple.backend.travel.entity.TravelDoc;
 import org.triple.backend.travel.entity.UserRole;
 import org.triple.backend.travel.entity.UserTravelItinerary;
 import org.triple.backend.travel.exception.TravelItineraryErrorCode;
@@ -30,6 +32,7 @@ import org.triple.backend.travel.dto.request.TravelItinerarySaveRequestDto;
 import org.triple.backend.travel.dto.response.TravelItinerarySaveResponseDto;
 import org.triple.backend.travel.entity.TravelItinerary;
 import org.triple.backend.travel.exception.UserTravelItineraryErrorCode;
+import org.triple.backend.travel.repository.TravelDocJpaRepository;
 import org.triple.backend.travel.repository.TravelItineraryJpaRepository;
 import org.triple.backend.travel.repository.UserTravelItineraryJpaRepository;
 import org.triple.backend.travel.service.TravelItineraryService;
@@ -38,6 +41,7 @@ import org.triple.backend.user.exception.UserErrorCode;
 import org.triple.backend.user.repository.UserJpaRepository;
 
 import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -66,6 +70,9 @@ class TravelItineraryServiceTest {
 
     @Autowired
     private TravelItineraryJpaRepository travelItineraryJpaRepository;
+
+    @Autowired
+    private TravelDocJpaRepository travelDocJpaRepository;
 
     @Autowired
     private UserTravelItineraryJpaRepository userTravelItineraryJpaRepository;
@@ -848,6 +855,77 @@ class TravelItineraryServiceTest {
 
         // when & then
         Assertions.assertThatThrownBy(() -> travelItineraryService.getTravelInfo(travelItinerary.getId(), user.getId()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserTravelItineraryErrorCode.USER_TRAVEL_ITINERARY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("여행 문서 초기값 조회 시 문서가 있으면 initialized=true를 반환한다.")
+    void 여행_문서_초기값_조회_문서있음() {
+        User user = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+        userTravelItineraryJpaRepository.save(UserTravelItinerary.of(user, travelItinerary, UserRole.LEADER));
+
+        byte[] state = new byte[]{0, 1, 2, 3};
+        travelDocJpaRepository.save(TravelDoc.of(travelItinerary.getId(), state));
+
+        TravelDocInitialStateResponseDto response = travelItineraryService.getTravelDocInitialState(
+                travelItinerary.getId(),
+                user.getId()
+        );
+
+        String encodedState = Base64.getEncoder().encodeToString(state);
+        Assertions.assertThat(response.travelItineraryId()).isEqualTo(travelItinerary.getId());
+        Assertions.assertThat(response.initialized()).isTrue();
+        Assertions.assertThat(response.state()).isEqualTo(encodedState);
+    }
+
+    @Test
+    @DisplayName("여행 문서 초기값 조회 시 문서가 없으면 initialized=false를 반환한다.")
+    void 여행_문서_초기값_조회_문서없음() {
+        User user = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+        userTravelItineraryJpaRepository.save(UserTravelItinerary.of(user, travelItinerary, UserRole.LEADER));
+
+        TravelDocInitialStateResponseDto response = travelItineraryService.getTravelDocInitialState(
+                travelItinerary.getId(),
+                user.getId()
+        );
+
+        Assertions.assertThat(response.travelItineraryId()).isEqualTo(travelItinerary.getId());
+        Assertions.assertThat(response.initialized()).isFalse();
+        Assertions.assertThat(response.state()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여행 문서 초기값 조회 시 여행 멤버가 아니면 예외를 던진다.")
+    void 여행_문서_초기값_조회_멤버아님_예외() {
+        User user = userJpaRepository.save(createUser());
+        Group group = groupJpaRepository.save(createGroup());
+        TravelItinerary travelItinerary = travelItineraryJpaRepository.save(new TravelItinerary(
+                "제주도 여행",
+                LocalDateTime.of(2026, 3, 1, 0, 0),
+                LocalDateTime.of(2026, 3, 5, 0, 0),
+                group, "설명", 1, false
+        ));
+
+        Assertions.assertThatThrownBy(() -> travelItineraryService.getTravelDocInitialState(
+                        travelItinerary.getId(),
+                        user.getId()
+                ))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(UserTravelItineraryErrorCode.USER_TRAVEL_ITINERARY_NOT_FOUND);


### PR DESCRIPTION
## PR 제목
`travel_itinerary_id` 기반 여행 문서 초기값 조회 API 추가 (`GET /travels/{travelId}/doc`)

## 변경 배경
협업 문서 초기 진입 시 `travel_doc` 테이블의 `state(LONGBLOB)`를 `travel_itinerary_id`로 조회할 수 있는 API가 필요했습니다.

## 주요 변경 사항
- 여행 문서 초기값 조회 엔드포인트 추가
  - `GET /travels/{travelId}/doc`
- `travel_doc` 조회용 도메인 추가
  - `TravelDoc` 엔티티
  - `TravelDocJpaRepository`
- 응답 DTO 추가
  - `TravelDocInitialStateResponseDto`
  - `state`는 Base64 문자열로 반환
- 서비스 로직 추가 (`TravelItineraryService#getTravelDocInitialState`)
  - 여행 존재 여부 검증
  - 여행 멤버 권한 검증
  - 문서 존재 시 `initialized=true`
  - 문서 미존재 시 `initialized=false`, `state=""`

## 응답 예시
- 문서 존재
```json
{
  "travelItineraryId": 123,
  "state": "AAECAw==",
  "initialized": true
}