### PR TITLE
리프레시 토큰 API 구현

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -5,23 +5,32 @@
 :toc: left
 :toclevels: 3
 
-== OAuth2 로그인
+== OAuth2 Login
 include::{snippets}/auth/login/http-request.adoc[]
 include::{snippets}/auth/login/http-response.adoc[]
 
-=== 실패: 잘못된 요청 값(400)
+=== Failure: Bad Request (400)
 include::{snippets}/auth/login-fail-bad-request/http-response.adoc[]
 
-=== 실패: 지원하지 않는 OAuth Provider (401)
+=== Failure: Unsupported OAuth Provider (401)
 include::{snippets}/auth/login-fail-unsupported-provider/http-response.adoc[]
 
-=== 실패: 카카오 인증 토큰 발급 실패 (401)
+=== Failure: Kakao Access Token Issue Failed (401)
 include::{snippets}/auth/login-fail-issue-kakao-access-token/http-response.adoc[]
 
-=== 실패: 카카오 사용자 정보 조회 실패 (401)
+=== Failure: Kakao User Info Lookup Failed (401)
 include::{snippets}/auth/login-fail-find-kakao-user-info/http-response.adoc[]
 
-== 인증 토큰 사용
+== Access Token Reissue (Refresh Token)
+include::{snippets}/auth/refresh/http-request.adoc[]
+include::{snippets}/auth/refresh/http-response.adoc[]
 
-- 로그인 성공 시 응답 헤더 `Authorization`으로 `Bearer <accessToken>`이 내려갑니다.
-- 인증이 필요한 API는 동일 헤더를 요청에 포함해야 합니다.
+=== Failure: Missing Or Invalid Refresh Cookie (401)
+include::{snippets}/auth/refresh-fail-unauthorized/http-response.adoc[]
+
+== Token Usage
+
+- On login success, server returns `Authorization: Bearer <accessToken>` header.
+- Server also returns `Set-Cookie: refresh_token=<token>` with `HttpOnly` option.
+- Use the access token in `Authorization` header for authenticated APIs.
+- Call `/auth/refresh` with refresh cookie to reissue access token and rotate refresh token.

--- a/src/main/java/org/triple/backend/auth/config/property/JwtProperties.java
+++ b/src/main/java/org/triple/backend/auth/config/property/JwtProperties.java
@@ -9,6 +9,11 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "security.jwt")
 public record JwtProperties(
         @NotBlank String secret,
-        @Min(1) long accessTokenExpireSeconds
+        @Min(1) long accessTokenExpireSeconds,
+        @Min(1) long refreshTokenExpireSeconds,
+        @NotBlank String refreshCookieName,
+        @NotBlank String refreshCookiePath,
+        boolean refreshCookieSecure,
+        @NotBlank String refreshCookieSameSite
 ) {
 }

--- a/src/main/java/org/triple/backend/auth/controller/AuthController.java
+++ b/src/main/java/org/triple/backend/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package org.triple.backend.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,13 @@ public class AuthController {
     @PostMapping("/login")
     public AuthLoginResponseDto login(@Valid @RequestBody final AuthLoginRequestDto authLoginRequestDto,
                                       HttpServletResponse response) {
-        log.debug("login 시작");
+        log.debug("login start");
         return authServiceFacade.login(authLoginRequestDto, response);
+    }
+
+    @PostMapping("/refresh")
+    public void refresh(HttpServletRequest request, HttpServletResponse response) {
+        log.debug("refresh start");
+        authServiceFacade.refresh(request, response);
     }
 }

--- a/src/main/java/org/triple/backend/auth/entity/RefreshToken.java
+++ b/src/main/java/org/triple/backend/auth/entity/RefreshToken.java
@@ -1,0 +1,43 @@
+package org.triple.backend.auth.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.triple.backend.global.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "refresh_token")
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String tokenHash;
+
+    private LocalDateTime expiresAt;
+
+    public static RefreshToken create(Long userId, String tokenHash, LocalDateTime expiresAt) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.userId = userId;
+        refreshToken.tokenHash = tokenHash;
+        refreshToken.expiresAt = expiresAt;
+        return refreshToken;
+    }
+
+    public void rotate(String nextTokenHash, LocalDateTime nextExpiresAt) {
+        this.tokenHash = nextTokenHash;
+        this.expiresAt = nextExpiresAt;
+    }
+}

--- a/src/main/java/org/triple/backend/auth/jwt/JwtCookieWriter.java
+++ b/src/main/java/org/triple/backend/auth/jwt/JwtCookieWriter.java
@@ -1,0 +1,28 @@
+package org.triple.backend.auth.jwt;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.triple.backend.auth.config.property.JwtProperties;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class JwtCookieWriter {
+
+    private final JwtProperties jwtProperties;
+
+    public void writeRefreshCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie refreshCookie = ResponseCookie.from(jwtProperties.refreshCookieName(), refreshToken)
+                .httpOnly(true)
+                .secure(jwtProperties.refreshCookieSecure())
+                .sameSite(jwtProperties.refreshCookieSameSite())
+                .path(jwtProperties.refreshCookiePath())
+                .maxAge(Duration.ofSeconds(jwtProperties.refreshTokenExpireSeconds()))
+                .build();
+
+        response.addHeader("Set-Cookie", refreshCookie.toString());
+    }
+}

--- a/src/main/java/org/triple/backend/auth/jwt/JwtManager.java
+++ b/src/main/java/org/triple/backend/auth/jwt/JwtManager.java
@@ -2,6 +2,7 @@ package org.triple.backend.auth.jwt;
 
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Base64;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -23,17 +26,30 @@ public class JwtManager {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String USER_ID = "userId";
+    private static final String TOKEN_TYPE = "tokenType";
+    private static final String ACCESS_TYPE = "ACCESS";
+    private static final String REFRESH_TYPE = "REFRESH";
 
     private final JwtProperties jwtProperties;
 
     public String createAccessToken(Long userId) {
+        return createToken(userId, ACCESS_TYPE, jwtProperties.accessTokenExpireSeconds());
+    }
+
+    public String createRefreshToken(Long userId) {
+        return createToken(userId, REFRESH_TYPE, jwtProperties.refreshTokenExpireSeconds());
+    }
+
+    private String createToken(Long userId, String tokenType, long expireSeconds) {
         SecretKey secretKey = secretKey();
         Instant now = Instant.now();
 
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .claim(USER_ID, userId)
+                .claim(TOKEN_TYPE, tokenType)
                 .issuedAt(Date.from(now))
-                .expiration(Date.from(now.plusSeconds(jwtProperties.accessTokenExpireSeconds())))
+                .expiration(Date.from(now.plusSeconds(expireSeconds)))
                 .signWith(secretKey)
                 .compact();
     }
@@ -48,21 +64,60 @@ public class JwtManager {
         if (token.isBlank()) throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
 
         try {
-            Object userIdObj = Jwts.parser()
-                    .verifyWith(secretKey())
-                    .build()
-                    .parseSignedClaims(token)
-                    .getPayload()
-                    .get(USER_ID);
-
-            if (userIdObj instanceof Number number) {
-                return number.longValue();
-            }
-            if (userIdObj instanceof String value && !value.isBlank()) {
-                return Long.parseLong(value);
-            }
-            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+            Claims claims = parse(token);
+            validateTokenType(claims, ACCESS_TYPE);
+            return extractUserId(claims);
         } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    public Long resolveUserIdFromRefreshToken(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        try {
+            Claims claims = parse(refreshToken);
+            validateTokenType(claims, REFRESH_TYPE);
+            return extractUserId(claims);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    public String hashToken(String token) {
+        if (token == null || token.isBlank()) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+        return Base64.getEncoder().encodeToString(hash(token));
+    }
+
+    private Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private Long extractUserId(Claims claims) {
+        Object userIdObj = claims.get(USER_ID);
+        if (userIdObj instanceof Number number) {
+            return number.longValue();
+        }
+        if (userIdObj instanceof String value && !value.isBlank()) {
+            return Long.parseLong(value);
+        }
+        throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    private void validateTokenType(Claims claims, String expectedType) {
+        Object tokenTypeObj = claims.get(TOKEN_TYPE);
+        if (!(tokenTypeObj instanceof String tokenType)) {
+            throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
+        }
+        if (!expectedType.equals(tokenType)) {
             throw new BusinessException(AuthErrorCode.UNAUTHORIZED);
         }
     }

--- a/src/main/java/org/triple/backend/auth/repository/RefreshTokenJpaRepository.java
+++ b/src/main/java/org/triple/backend/auth/repository/RefreshTokenJpaRepository.java
@@ -1,0 +1,11 @@
+package org.triple.backend.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.triple.backend.auth.entity.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findTopByUserIdOrderByIdDesc(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/org/triple/backend/auth/service/AuthService.java
+++ b/src/main/java/org/triple/backend/auth/service/AuthService.java
@@ -1,55 +1,130 @@
 package org.triple.backend.auth.service;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.triple.backend.auth.config.property.JwtProperties;
 import org.triple.backend.auth.crypto.UuidToUserIdCache;
 import org.triple.backend.auth.dto.request.AuthLoginRequestDto;
 import org.triple.backend.auth.dto.response.AuthLoginResponseDto;
+import org.triple.backend.auth.entity.RefreshToken;
 import org.triple.backend.auth.exception.AuthErrorCode;
+import org.triple.backend.auth.jwt.JwtCookieWriter;
 import org.triple.backend.auth.jwt.JwtManager;
 import org.triple.backend.auth.oauth.OauthClient;
 import org.triple.backend.auth.oauth.OauthProvider;
 import org.triple.backend.auth.oauth.OauthUser;
+import org.triple.backend.auth.repository.RefreshTokenJpaRepository;
 import org.triple.backend.global.error.BusinessException;
 import org.triple.backend.global.log.MaskUtil;
 import org.triple.backend.user.entity.User;
 import org.triple.backend.user.repository.UserJpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+    private static final String BEARER_PREFIX = "Bearer ";
+
     private final UuidToUserIdCache uuidToUserIdCache;
     private final Map<OauthProvider, OauthClient> clients;
     private final UserJpaRepository userJpaRepository;
+    private final RefreshTokenJpaRepository refreshTokenJpaRepository;
     private final JwtManager jwtManager;
+    private final JwtCookieWriter jwtCookieWriter;
+    private final JwtProperties jwtProperties;
 
     public OauthUser authenticate(AuthLoginRequestDto authLoginRequestDto) {
         OauthClient client = clients.get(authLoginRequestDto.provider());
-        if(client == null) {
+        if (client == null) {
             throw new BusinessException(AuthErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
         }
         log.debug("client = {}", client.provider());
         return client.fetchUser(authLoginRequestDto.code());
     }
 
-    @Transactional()
+    @Transactional
     public AuthLoginResponseDto findOrCreate(OauthUser oauthUser, HttpServletResponse response) {
         User user = userJpaRepository.findByProviderAndProviderId(oauthUser.provider(), oauthUser.providerId())
                 .orElseGet(() -> signup(oauthUser));
 
         user.assignPublicUuidIfAbsent();
-        log.debug("유저 정보 정상적으로 받아옴 = {}", MaskUtil.maskString(user.getPublicUuid().toString()));
         uuidToUserIdCache.save(user.getPublicUuid(), user.getId());
-        log.debug("유저 정보 정상적으로 캐싱");
-        response.setHeader("Authorization", "Bearer " + jwtManager.createAccessToken(user.getId()));
-        log.debug("헤더 토큰 = {}", response.getHeader("Authorization"));
+        log.debug("user session initialized: {}", MaskUtil.maskString(user.getPublicUuid().toString()));
+
+        String accessToken = jwtManager.createAccessToken(user.getId());
+        String refreshToken = jwtManager.createRefreshToken(user.getId());
+        replaceRefreshToken(user.getId(), refreshToken);
+
+        response.setHeader(JwtManager.AUTHORIZATION_HEADER, BEARER_PREFIX + accessToken);
+        jwtCookieWriter.writeRefreshCookie(response, refreshToken);
         return AuthLoginResponseDto.from(user);
+    }
+
+    @Transactional
+    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = resolveRefreshTokenFromCookie(request);
+        Long userId = jwtManager.resolveUserIdFromRefreshToken(refreshToken);
+
+        RefreshToken storedRefreshToken = refreshTokenJpaRepository.findTopByUserIdOrderByIdDesc(userId)
+                .orElseThrow(this::unauthorized);
+        validateStoredRefreshToken(storedRefreshToken, refreshToken);
+
+        String nextAccessToken = jwtManager.createAccessToken(userId);
+        String nextRefreshToken = jwtManager.createRefreshToken(userId);
+        replaceRefreshToken(userId, nextRefreshToken);
+
+        response.setHeader(JwtManager.AUTHORIZATION_HEADER, BEARER_PREFIX + nextAccessToken);
+        jwtCookieWriter.writeRefreshCookie(response, nextRefreshToken);
+    }
+
+    private String resolveRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            throw unauthorized();
+        }
+
+        for (Cookie cookie : cookies) {
+            if (!jwtProperties.refreshCookieName().equals(cookie.getName())) {
+                continue;
+            }
+
+            String refreshToken = cookie.getValue();
+            if (refreshToken == null || refreshToken.isBlank()) {
+                throw unauthorized();
+            }
+            return refreshToken;
+        }
+
+        throw unauthorized();
+    }
+
+    private void validateStoredRefreshToken(RefreshToken storedRefreshToken, String refreshToken) {
+        String tokenHash = storedRefreshToken.getTokenHash();
+        if (tokenHash == null || !tokenHash.equals(jwtManager.hashToken(refreshToken))) {
+            throw unauthorized();
+        }
+
+        LocalDateTime expiresAt = storedRefreshToken.getExpiresAt();
+        if (expiresAt == null || expiresAt.isBefore(LocalDateTime.now())) {
+            throw unauthorized();
+        }
+    }
+
+    private void replaceRefreshToken(Long userId, String refreshToken) {
+        String tokenHash = jwtManager.hashToken(refreshToken);
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(jwtProperties.refreshTokenExpireSeconds());
+
+        refreshTokenJpaRepository.deleteByUserId(userId);
+        RefreshToken nextRefreshToken = RefreshToken.create(userId, tokenHash, expiresAt);
+        refreshTokenJpaRepository.save(nextRefreshToken);
     }
 
     private User signup(final OauthUser oauthUser) {
@@ -62,5 +137,9 @@ public class AuthService {
                 .build();
 
         return userJpaRepository.save(user);
+    }
+
+    private BusinessException unauthorized() {
+        return new BusinessException(AuthErrorCode.UNAUTHORIZED);
     }
 }

--- a/src/main/java/org/triple/backend/auth/service/AuthServiceFacade.java
+++ b/src/main/java/org/triple/backend/auth/service/AuthServiceFacade.java
@@ -1,5 +1,6 @@
 package org.triple.backend.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,10 @@ public class AuthServiceFacade {
 
     public AuthLoginResponseDto login(final AuthLoginRequestDto authLoginRequestDto, HttpServletResponse response) {
         OauthUser oauthUser = authService.authenticate(authLoginRequestDto);
-
         return authService.findOrCreate(oauthUser, response);
+    }
+
+    public void refresh(HttpServletRequest request, HttpServletResponse response) {
+        authService.reissueAccessToken(request, response);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,6 +51,11 @@ security:
   jwt:
     secret: ${JWT_SECRET}
     access-token-expire-seconds: ${JWT_ACCESS_TOKEN_EXPIRE_SECONDS:86400}
+    refresh-token-expire-seconds: ${JWT_REFRESH_TOKEN_EXPIRE_SECONDS:1209600}
+    refresh-cookie-name: ${JWT_REFRESH_COOKIE_NAME:refresh_token}
+    refresh-cookie-path: ${JWT_REFRESH_COOKIE_PATH:/auth}
+    refresh-cookie-secure: ${JWT_REFRESH_COOKIE_SECURE:true}
+    refresh-cookie-same-site: ${JWT_REFRESH_COOKIE_SAMESITE:None}
   uuid:
     secret: ${UUID_CRYPTO_SECRET}
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,6 +49,11 @@ security:
   jwt:
     secret: ${JWT_SECRET:local-dev-jwt-secret-change-me}
     access-token-expire-seconds: ${JWT_ACCESS_TOKEN_EXPIRE_SECONDS:86400}
+    refresh-token-expire-seconds: ${JWT_REFRESH_TOKEN_EXPIRE_SECONDS:1209600}
+    refresh-cookie-name: ${JWT_REFRESH_COOKIE_NAME:refresh_token}
+    refresh-cookie-path: ${JWT_REFRESH_COOKIE_PATH:/auth}
+    refresh-cookie-secure: ${JWT_REFRESH_COOKIE_SECURE:false}
+    refresh-cookie-same-site: ${JWT_REFRESH_COOKIE_SAMESITE:Lax}
   uuid:
     secret: ${UUID_CRYPTO_SECRET:local-dev-uuid-secret-change-me}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -59,6 +59,11 @@ security:
   jwt:
     secret: ${JWT_SECRET}
     access-token-expire-seconds: ${JWT_ACCESS_TOKEN_EXPIRE_SECONDS:86400}
+    refresh-token-expire-seconds: ${JWT_REFRESH_TOKEN_EXPIRE_SECONDS:1209600}
+    refresh-cookie-name: ${JWT_REFRESH_COOKIE_NAME:refresh_token}
+    refresh-cookie-path: ${JWT_REFRESH_COOKIE_PATH:/auth}
+    refresh-cookie-secure: ${JWT_REFRESH_COOKIE_SECURE:true}
+    refresh-cookie-same-site: ${JWT_REFRESH_COOKIE_SAMESITE:None}
   uuid:
     secret: ${UUID_CRYPTO_SECRET}
 

--- a/src/test/java/org/triple/backend/auth/integration/AuthIntegrationTest.java
+++ b/src/test/java/org/triple/backend/auth/integration/AuthIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.triple.backend.auth.integration;
 
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.triple.backend.user.repository.UserJpaRepository;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -49,7 +51,7 @@ class AuthIntegrationTest {
     }
 
     @Test
-    @DisplayName("kakao login success returns authorization header and profile")
+    @DisplayName("kakao login success returns authorization header, refresh cookie and profile")
     void loginSuccess() throws Exception {
         given(kakaoOauthClient.fetchUser(anyString()))
                 .willReturn(new OauthUser(
@@ -67,6 +69,7 @@ class AuthIntegrationTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Authorization", startsWith("Bearer ")))
+                .andExpect(header().string("Set-Cookie", containsString("refresh_token=")))
                 .andExpect(jsonPath("$.profileUrl").value("http://img"))
                 .andExpect(jsonPath("$.nickname").value("test"))
                 .andExpect(jsonPath("$.email").value("test@test.com"))
@@ -75,11 +78,82 @@ class AuthIntegrationTest {
         User saved = userJpaRepository.findByProviderAndProviderId(OauthProvider.KAKAO, "kakao-1234")
                 .orElseThrow();
         String authorizationHeader = result.getResponse().getHeader("Authorization");
+        String setCookie = result.getResponse().getHeader("Set-Cookie");
 
         assertThat(authorizationHeader).startsWith("Bearer ");
         assertThat(authorizationHeader).isNotBlank();
+        assertThat(setCookie).contains("refresh_token=");
         assertThat(saved.getId()).isNotNull();
         assertThat(userJpaRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("refresh success returns new authorization header and rotated refresh cookie")
+    void refreshSuccess() throws Exception {
+        given(kakaoOauthClient.fetchUser(anyString()))
+                .willReturn(new OauthUser(
+                        OauthProvider.KAKAO,
+                        "kakao-5678",
+                        "refresh@test.com",
+                        "refresh-user",
+                        "http://img"
+                ));
+
+        MvcResult loginResult = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"code":"test-code","provider":"KAKAO"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Cookie refreshCookie = toRefreshCookie(loginResult.getResponse().getHeader("Set-Cookie"));
+
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(refreshCookie))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Authorization", startsWith("Bearer ")))
+                .andExpect(header().string("Set-Cookie", containsString("refresh_token=")));
+    }
+
+    @Test
+    @DisplayName("refresh without cookie returns unauthorized")
+    void refreshWithoutCookie() throws Exception {
+        mockMvc.perform(post("/auth/refresh"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("refresh with stale cookie returns unauthorized")
+    void refreshWithStaleCookie() throws Exception {
+        given(kakaoOauthClient.fetchUser(anyString()))
+                .willReturn(new OauthUser(
+                        OauthProvider.KAKAO,
+                        "kakao-9999",
+                        "stale@test.com",
+                        "stale-user",
+                        "http://img"
+                ));
+
+        MvcResult firstLogin = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"code":"test-code","provider":"KAKAO"}
+                                """))
+                .andExpect(status().isOk())
+                .andReturn();
+        Cookie staleCookie = toRefreshCookie(firstLogin.getResponse().getHeader("Set-Cookie"));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"code":"test-code","provider":"KAKAO"}
+                                """))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(staleCookie))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -93,5 +167,11 @@ class AuthIntegrationTest {
                 .andExpect(status().is4xxClientError());
 
         assertThat(userJpaRepository.count()).isEqualTo(0);
+    }
+
+    private Cookie toRefreshCookie(String setCookieHeader) {
+        String firstSection = setCookieHeader.split(";", 2)[0];
+        String[] cookieParts = firstSection.split("=", 2);
+        return new Cookie(cookieParts[0], cookieParts[1]);
     }
 }

--- a/src/test/java/org/triple/backend/auth/unit/controller/AuthControllerTest.java
+++ b/src/test/java/org/triple/backend/auth/unit/controller/AuthControllerTest.java
@@ -23,6 +23,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -50,6 +54,9 @@ class AuthControllerTest extends ControllerTest {
                         .content("""
                                 {"code":"test-code","provider":"KAKAO"}
                                 """))
+                .andDo(document("auth/login",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Authorization", startsWith("Bearer ")))
                 .andExpect(header().string("Set-Cookie", startsWith("refresh_token=")))
@@ -68,6 +75,9 @@ class AuthControllerTest extends ControllerTest {
                         .content("""
                                 {"code":"","provider":null}
                                 """))
+                .andDo(document("auth/login-fail-bad-request",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").exists());
 
@@ -85,7 +95,46 @@ class AuthControllerTest extends ControllerTest {
                         .content("""
                                 {"code":"test-code","provider":"GOOGLE"}
                                 """))
+                .andDo(document("auth/login-fail-unsupported-provider",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("kakao access token issue failure returns unauthorized")
+    void loginFailIssueKakaoAccessToken() throws Exception {
+        given(authServiceFacade.login(any(AuthLoginRequestDto.class), any(HttpServletResponse.class)))
+                .willThrow(new BusinessException(AuthErrorCode.FAILED_ISSUE_KAKAO_ACCESS_TOKEN));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"code":"test-code","provider":"KAKAO"}
+                                """))
+                .andDo(document("auth/login-fail-issue-kakao-access-token",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(AuthErrorCode.FAILED_ISSUE_KAKAO_ACCESS_TOKEN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("kakao user info fetch failure returns unauthorized")
+    void loginFailFindKakaoUserInfo() throws Exception {
+        given(authServiceFacade.login(any(AuthLoginRequestDto.class), any(HttpServletResponse.class)))
+                .willThrow(new BusinessException(AuthErrorCode.FAILED_FIND_KAKAO_USER_INFO));
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"code":"test-code","provider":"KAKAO"}
+                                """))
+                .andDo(document("auth/login-fail-find-kakao-user-info",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value(AuthErrorCode.FAILED_FIND_KAKAO_USER_INFO.getMessage()));
     }
 
     @Test
@@ -102,6 +151,9 @@ class AuthControllerTest extends ControllerTest {
 
         mockMvc.perform(post("/auth/refresh")
                         .cookie(new Cookie("refresh_token", "old-refresh-token")))
+                .andDo(document("auth/refresh",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Authorization", startsWith("Bearer ")))
                 .andExpect(header().string("Set-Cookie", startsWith("refresh_token=")));
@@ -117,6 +169,9 @@ class AuthControllerTest extends ControllerTest {
                 .refresh(any(HttpServletRequest.class), any(HttpServletResponse.class));
 
         mockMvc.perform(post("/auth/refresh"))
+                .andDo(document("auth/refresh-fail-unauthorized",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/org/triple/backend/auth/unit/controller/AuthControllerTest.java
+++ b/src/test/java/org/triple/backend/auth/unit/controller/AuthControllerTest.java
@@ -1,6 +1,8 @@
 package org.triple.backend.auth.unit.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -33,12 +35,13 @@ class AuthControllerTest extends ControllerTest {
     private AuthServiceFacade authServiceFacade;
 
     @Test
-    @DisplayName("login success returns profile response and authorization header")
+    @DisplayName("login success returns profile response, authorization header and refresh cookie")
     void loginSuccess() throws Exception {
         given(authServiceFacade.login(any(AuthLoginRequestDto.class), any(HttpServletResponse.class)))
                 .willAnswer(invocation -> {
                     HttpServletResponse response = invocation.getArgument(1, HttpServletResponse.class);
                     response.setHeader("Authorization", "Bearer access-token");
+                    response.addHeader("Set-Cookie", "refresh_token=refresh-token; Path=/auth; HttpOnly");
                     return new AuthLoginResponseDto("test", "test@test.com", "http://img");
                 });
 
@@ -49,6 +52,7 @@ class AuthControllerTest extends ControllerTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(header().string("Authorization", startsWith("Bearer ")))
+                .andExpect(header().string("Set-Cookie", startsWith("refresh_token=")))
                 .andExpect(jsonPath("$.nickname").value("test"))
                 .andExpect(jsonPath("$.email").value("test@test.com"))
                 .andExpect(jsonPath("$.profileUrl").value("http://img"));
@@ -81,6 +85,38 @@ class AuthControllerTest extends ControllerTest {
                         .content("""
                                 {"code":"test-code","provider":"GOOGLE"}
                                 """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("refresh success returns authorization header and rotated refresh cookie")
+    void refreshSuccess() throws Exception {
+        org.mockito.BDDMockito.willAnswer(invocation -> {
+                    HttpServletResponse response = invocation.getArgument(1, HttpServletResponse.class);
+                    response.setHeader("Authorization", "Bearer new-access-token");
+                    response.addHeader("Set-Cookie", "refresh_token=new-refresh-token; Path=/auth; HttpOnly");
+                    return null;
+                })
+                .given(authServiceFacade)
+                .refresh(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(new Cookie("refresh_token", "old-refresh-token")))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Authorization", startsWith("Bearer ")))
+                .andExpect(header().string("Set-Cookie", startsWith("refresh_token=")));
+
+        verify(authServiceFacade, times(1)).refresh(any(HttpServletRequest.class), any(HttpServletResponse.class));
+    }
+
+    @Test
+    @DisplayName("refresh without cookie returns unauthorized")
+    void refreshWithoutCookie() throws Exception {
+        org.mockito.BDDMockito.willThrow(new BusinessException(AuthErrorCode.UNAUTHORIZED))
+                .given(authServiceFacade)
+                .refresh(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        mockMvc.perform(post("/auth/refresh"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/org/triple/backend/auth/unit/jwt/JwtManagerTest.java
+++ b/src/test/java/org/triple/backend/auth/unit/jwt/JwtManagerTest.java
@@ -13,12 +13,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class JwtManagerTest {
 
     private final JwtManager jwtManager = new JwtManager(
-            new JwtProperties("test-jwt-secret-value-at-least-32-characters", 3600)
+            new JwtProperties(
+                    "test-jwt-secret-value-at-least-32-characters",
+                    3600,
+                    1209600L,
+                    "refresh_token",
+                    "/auth",
+                    false,
+                    "Lax"
+            )
     );
 
     @Test
-    @DisplayName("JWT 생성 후 Authorization 헤더에서 userId를 복원한다")
-    void create_and_parse_success() {
+    @DisplayName("creates access token and resolves user id from authorization header")
+    void createAndParseAccessTokenSuccess() {
         String token = jwtManager.createAccessToken(1L);
 
         Long userId = jwtManager.resolveUserId("Bearer " + token);
@@ -27,17 +35,49 @@ class JwtManagerTest {
     }
 
     @Test
-    @DisplayName("Authorization 헤더가 없으면 null을 반환한다")
-    void missing_header_returns_null() {
+    @DisplayName("returns null when authorization header is missing")
+    void missingHeaderReturnsNull() {
         Long userId = jwtManager.resolveUserId(null);
 
         assertThat(userId).isNull();
     }
 
     @Test
-    @DisplayName("잘못된 토큰이면 UNAUTHORIZED 예외를 던진다")
-    void invalid_token_throws_unauthorized() {
+    @DisplayName("throws unauthorized for invalid access token")
+    void invalidAccessTokenThrowsUnauthorized() {
         assertThatThrownBy(() -> jwtManager.resolveUserId("Bearer invalid-token"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("creates refresh token and resolves user id")
+    void createAndParseRefreshTokenSuccess() {
+        String refreshToken = jwtManager.createRefreshToken(11L);
+
+        Long userId = jwtManager.resolveUserIdFromRefreshToken(refreshToken);
+
+        assertThat(userId).isEqualTo(11L);
+    }
+
+    @Test
+    @DisplayName("throws unauthorized when access token is used as refresh token")
+    void accessTokenUsedAsRefreshTokenThrowsUnauthorized() {
+        String accessToken = jwtManager.createAccessToken(1L);
+
+        assertThatThrownBy(() -> jwtManager.resolveUserIdFromRefreshToken(accessToken))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("throws unauthorized when refresh token is used as access token")
+    void refreshTokenUsedAsAccessTokenThrowsUnauthorized() {
+        String refreshToken = jwtManager.createRefreshToken(1L);
+
+        assertThatThrownBy(() -> jwtManager.resolveUserId("Bearer " + refreshToken))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(AuthErrorCode.UNAUTHORIZED);

--- a/src/test/java/org/triple/backend/auth/unit/service/AuthServiceTest.java
+++ b/src/test/java/org/triple/backend/auth/unit/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package org.triple.backend.auth.unit.service;
 
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,23 +8,28 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.triple.backend.auth.config.property.JwtProperties;
 import org.triple.backend.auth.crypto.UuidToUserIdCache;
 import org.triple.backend.auth.dto.request.AuthLoginRequestDto;
 import org.triple.backend.auth.dto.response.AuthLoginResponseDto;
+import org.triple.backend.auth.entity.RefreshToken;
 import org.triple.backend.auth.exception.AuthErrorCode;
+import org.triple.backend.auth.jwt.JwtCookieWriter;
 import org.triple.backend.auth.jwt.JwtManager;
 import org.triple.backend.auth.oauth.OauthClient;
 import org.triple.backend.auth.oauth.OauthProvider;
 import org.triple.backend.auth.oauth.OauthUser;
+import org.triple.backend.auth.repository.RefreshTokenJpaRepository;
 import org.triple.backend.auth.service.AuthService;
 import org.triple.backend.common.annotation.ServiceTest;
 import org.triple.backend.global.error.BusinessException;
 import org.triple.backend.user.entity.User;
 import org.triple.backend.user.repository.UserJpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +38,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 @ServiceTest
-@Import({AuthService.class, JwtManager.class, AuthServiceTest.JwtTestConfig.class})
+@Import({AuthService.class, JwtManager.class, JwtCookieWriter.class, AuthServiceTest.JwtTestConfig.class})
 class AuthServiceTest {
 
     @Autowired
@@ -43,6 +49,9 @@ class AuthServiceTest {
 
     @Autowired
     private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private RefreshTokenJpaRepository refreshTokenJpaRepository;
 
     @MockitoBean
     private UuidToUserIdCache uuidToUserIdCache;
@@ -55,6 +64,7 @@ class AuthServiceTest {
 
     @BeforeEach
     void setUp() {
+        refreshTokenJpaRepository.deleteAll();
         userJpaRepository.deleteAll();
     }
 
@@ -90,8 +100,8 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("findOrCreate creates user and sets authorization header")
-    void findOrCreateCreatesUserAndSetsJwtHeader() {
+    @DisplayName("findOrCreate creates user and returns access header and refresh cookie")
+    void findOrCreateCreatesUserAndReturnsTokens() {
         OauthUser oauthUser = new OauthUser(
                 OauthProvider.KAKAO,
                 "kakao-999",
@@ -105,19 +115,30 @@ class AuthServiceTest {
 
         User saved = userJpaRepository.findByProviderAndProviderId(OauthProvider.KAKAO, "kakao-999")
                 .orElseThrow();
+        RefreshToken savedRefreshToken = refreshTokenJpaRepository.findTopByUserIdOrderByIdDesc(saved.getId())
+                .orElseThrow();
         String authorizationHeader = response.getHeader("Authorization");
+        String cookieHeader = response.getHeader("Set-Cookie");
+        String refreshToken = extractRefreshToken(cookieHeader);
 
         assertThat(result.nickname()).isEqualTo("newbie");
         assertThat(result.email()).isEqualTo("new@test.com");
         assertThat(result.profileUrl()).isEqualTo("http://img");
         assertThat(authorizationHeader).startsWith("Bearer ");
         assertThat(jwtManager.resolveUserId(authorizationHeader)).isEqualTo(saved.getId());
+        assertThat(cookieHeader).startsWith("refresh_token=");
+        assertThat(cookieHeader).contains("HttpOnly");
+        assertThat(cookieHeader).contains("Path=/auth");
+        assertThat(jwtManager.resolveUserIdFromRefreshToken(refreshToken)).isEqualTo(saved.getId());
+        assertThat(savedRefreshToken.getTokenHash()).isEqualTo(jwtManager.hashToken(refreshToken));
+        assertThat(savedRefreshToken.getExpiresAt()).isAfter(LocalDateTime.now().minusSeconds(1));
         assertThat(userJpaRepository.count()).isEqualTo(1);
+        assertThat(refreshTokenJpaRepository.count()).isEqualTo(1);
         verify(uuidToUserIdCache).save(saved.getPublicUuid(), saved.getId());
     }
 
     @Test
-    @DisplayName("findOrCreate reuses existing user and does not duplicate")
+    @DisplayName("findOrCreate reuses existing user and rotates refresh token row")
     void findOrCreateExistingUser() {
         User existing = userJpaRepository.save(User.builder()
                 .provider(OauthProvider.KAKAO)
@@ -126,6 +147,9 @@ class AuthServiceTest {
                 .nickname("nick")
                 .profileUrl("http://img")
                 .build());
+        refreshTokenJpaRepository.save(
+                RefreshToken.create(existing.getId(), "old-token-hash", LocalDateTime.now().plusHours(1))
+        );
 
         OauthUser oauthUser = new OauthUser(
                 OauthProvider.KAKAO,
@@ -140,21 +164,154 @@ class AuthServiceTest {
 
         User found = userJpaRepository.findByProviderAndProviderId(OauthProvider.KAKAO, "kakao-123")
                 .orElseThrow();
+        RefreshToken savedRefreshToken = refreshTokenJpaRepository.findTopByUserIdOrderByIdDesc(found.getId())
+                .orElseThrow();
         String authorizationHeader = response.getHeader("Authorization");
+        String cookieHeader = response.getHeader("Set-Cookie");
+        String refreshToken = extractRefreshToken(cookieHeader);
 
         assertThat(userJpaRepository.count()).isEqualTo(1);
+        assertThat(refreshTokenJpaRepository.count()).isEqualTo(1);
         assertThat(found.getId()).isEqualTo(existing.getId());
         assertThat(result.nickname()).isEqualTo(existing.getNickname());
         assertThat(authorizationHeader).startsWith("Bearer ");
         assertThat(jwtManager.resolveUserId(authorizationHeader)).isEqualTo(existing.getId());
+        assertThat(savedRefreshToken.getTokenHash()).isEqualTo(jwtManager.hashToken(refreshToken));
+        assertThat(savedRefreshToken.getTokenHash()).isNotEqualTo("old-token-hash");
         verify(uuidToUserIdCache).save(found.getPublicUuid(), existing.getId());
+    }
+
+    @Test
+    @DisplayName("reissueAccessToken validates cookie and rotates refresh token")
+    void reissueAccessTokenSuccess() {
+        OauthUser oauthUser = new OauthUser(
+                OauthProvider.KAKAO,
+                "kakao-777",
+                "refresh@test.com",
+                "refresh-user",
+                "http://img"
+        );
+        MockHttpServletResponse loginResponse = new MockHttpServletResponse();
+        authService.findOrCreate(oauthUser, loginResponse);
+
+        User saved = userJpaRepository.findByProviderAndProviderId(OauthProvider.KAKAO, "kakao-777")
+                .orElseThrow();
+        String oldRefreshToken = extractRefreshToken(loginResponse.getHeader("Set-Cookie"));
+
+        MockHttpServletRequest refreshRequest = new MockHttpServletRequest();
+        refreshRequest.setCookies(new Cookie("refresh_token", oldRefreshToken));
+        MockHttpServletResponse refreshResponse = new MockHttpServletResponse();
+
+        authService.reissueAccessToken(refreshRequest, refreshResponse);
+
+        String refreshedAuthorizationHeader = refreshResponse.getHeader("Authorization");
+        String refreshedCookieHeader = refreshResponse.getHeader("Set-Cookie");
+        String newRefreshToken = extractRefreshToken(refreshedCookieHeader);
+        RefreshToken refreshed = refreshTokenJpaRepository.findTopByUserIdOrderByIdDesc(saved.getId())
+                .orElseThrow();
+
+        assertThat(refreshedAuthorizationHeader).startsWith("Bearer ");
+        assertThat(jwtManager.resolveUserId(refreshedAuthorizationHeader)).isEqualTo(saved.getId());
+        assertThat(refreshedCookieHeader).startsWith("refresh_token=");
+        assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
+        assertThat(jwtManager.resolveUserIdFromRefreshToken(newRefreshToken)).isEqualTo(saved.getId());
+        assertThat(refreshed.getTokenHash()).isEqualTo(jwtManager.hashToken(newRefreshToken));
+        assertThat(refreshTokenJpaRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("reissueAccessToken without refresh cookie throws unauthorized")
+    void reissueAccessTokenWithoutCookie() {
+        MockHttpServletRequest refreshRequest = new MockHttpServletRequest();
+        MockHttpServletResponse refreshResponse = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> authService.reissueAccessToken(refreshRequest, refreshResponse))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("reissueAccessToken with expired db token throws unauthorized")
+    void reissueAccessTokenWithExpiredDbToken() {
+        OauthUser oauthUser = new OauthUser(
+                OauthProvider.KAKAO,
+                "kakao-888",
+                "expired@test.com",
+                "expired-user",
+                "http://img"
+        );
+        MockHttpServletResponse loginResponse = new MockHttpServletResponse();
+        authService.findOrCreate(oauthUser, loginResponse);
+
+        User saved = userJpaRepository.findByProviderAndProviderId(OauthProvider.KAKAO, "kakao-888")
+                .orElseThrow();
+        RefreshToken stored = refreshTokenJpaRepository.findTopByUserIdOrderByIdDesc(saved.getId())
+                .orElseThrow();
+        stored.rotate(stored.getTokenHash(), LocalDateTime.now().minusSeconds(1));
+        refreshTokenJpaRepository.save(stored);
+
+        String refreshToken = extractRefreshToken(loginResponse.getHeader("Set-Cookie"));
+        MockHttpServletRequest refreshRequest = new MockHttpServletRequest();
+        refreshRequest.setCookies(new Cookie("refresh_token", refreshToken));
+        MockHttpServletResponse refreshResponse = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> authService.reissueAccessToken(refreshRequest, refreshResponse))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("reissueAccessToken with mismatched db hash throws unauthorized")
+    void reissueAccessTokenWithMismatchedDbHash() {
+        OauthUser oauthUser = new OauthUser(
+                OauthProvider.KAKAO,
+                "kakao-889",
+                "mismatch@test.com",
+                "mismatch-user",
+                "http://img"
+        );
+        MockHttpServletResponse loginResponse = new MockHttpServletResponse();
+        authService.findOrCreate(oauthUser, loginResponse);
+
+        User saved = userJpaRepository.findByProviderAndProviderId(OauthProvider.KAKAO, "kakao-889")
+                .orElseThrow();
+        RefreshToken stored = refreshTokenJpaRepository.findTopByUserIdOrderByIdDesc(saved.getId())
+                .orElseThrow();
+        stored.rotate("different-token-hash", LocalDateTime.now().plusHours(1));
+        refreshTokenJpaRepository.save(stored);
+
+        String refreshToken = extractRefreshToken(loginResponse.getHeader("Set-Cookie"));
+        MockHttpServletRequest refreshRequest = new MockHttpServletRequest();
+        refreshRequest.setCookies(new Cookie("refresh_token", refreshToken));
+        MockHttpServletResponse refreshResponse = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> authService.reissueAccessToken(refreshRequest, refreshResponse))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.UNAUTHORIZED);
+    }
+
+    private String extractRefreshToken(String cookieHeader) {
+        String firstSection = cookieHeader.split(";", 2)[0];
+        String[] tokenParts = firstSection.split("=", 2);
+        return tokenParts[1];
     }
 
     @TestConfiguration
     static class JwtTestConfig {
         @Bean
         JwtProperties jwtProperties() {
-            return new JwtProperties("test-jwt-secret-value-at-least-32-characters", 3600);
+            return new JwtProperties(
+                    "test-jwt-secret-value-at-least-32-characters",
+                    3600,
+                    1209600L,
+                    "refresh_token",
+                    "/auth",
+                    false,
+                    "Lax"
+            );
         }
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -61,6 +61,11 @@ security:
   jwt:
     secret: test-jwt-secret-value-at-least-32-characters
     access-token-expire-seconds: 3600
+    refresh-token-expire-seconds: 1209600
+    refresh-cookie-name: refresh_token
+    refresh-cookie-path: /auth
+    refresh-cookie-secure: false
+    refresh-cookie-same-site: Lax
   uuid:
     secret: test-uuid-crypto-secret
 


### PR DESCRIPTION
JWT 인증 흐름에 **Refresh Token(쿠키 + DB 저장 방식)** 을 추가하고, `/auth/refresh` 재발급 API 및 관련 테스트/문서를 반영했습니다.

## 주요 변경

- 로그인 성공 시
  - `Authorization: Bearer <accessToken>` 헤더 반환
  - `refresh_token` HttpOnly 쿠키 발급
  - Refresh Token 해시를 DB(`refresh_token`)에 저장
- Refresh 재발급 API 추가
  - `POST /auth/refresh`
  - 쿠키의 refresh token + DB 저장 해시 + 만료시간 검증
  - 성공 시 access token 재발급 + refresh token 회전(rotate)
- JWT 토큰 타입 분리
  - ACCESS/REFRESH claim 분리 검증
  - refresh 토큰 오용(access로 사용 등) 차단
- Auth 문서 보강
  - `auth.adoc`에 login/refresh 성공/실패 케이스 반영
  - REST Docs 스니펫 생성 로직(`AuthControllerTest`) 추가